### PR TITLE
fix: unpublish requests should not use outdated packuments from the local cache and should alway fetch the latest packument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libnpmpublish",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libnpmpublish",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Programmatic API for the bits behind npm publish and unpublish",
   "author": {
     "name": "Kat Marchán",

--- a/unpublish.js
+++ b/unpublish.js
@@ -20,6 +20,7 @@ function unpublish (spec, opts) {
     opts = opts.concat({ spec })
     const pkgUri = spec.escapedName
     return npmFetch.json(pkgUri, opts.concat({
+      'prefer-online': true,
       query: { write: true }
     })).then(pkg => {
       if (!spec.rawSpec || spec.rawSpec === '*') {
@@ -66,6 +67,7 @@ function unpublish (spec, opts) {
           })).then(() => {
             // Remove the tarball itself
             return npmFetch.json(pkgUri, opts.concat({
+              'prefer-online': true,
               query: { write: true }
             })).then(({ _rev, _id }) => {
               const tarballUrl = url.parse(dist.tarball).pathname.substr(1)


### PR DESCRIPTION
# What / Why

This fixes an existing production bug in the npm cli when running npm unpublish for a specific package version. When run an unpublish request is run successfully the first time, the packument is cached and is valid for 5 mins, so any attempts to unpublish another version within that 5min time frame are met with an error from the registry because the unpublished version still listed in the outdated cached version of the packument.

**To reproduce the current bug:**
- Successfully unpublish a version of a package via `npm unpublish packageA@1.0.2`
- Within 5 min, try and unpublish another version of that same package
- Observe:  an error from the registry saying "Cannot publish over previously published version "1.0.2". 


