### PR TITLE
Removing leading / causes incorrect uri on unpublish

### DIFF
--- a/test/unpublish.js
+++ b/test/unpublish.js
@@ -23,7 +23,7 @@ t.test('basic test', async t => {
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       }
     }
@@ -47,7 +47,7 @@ t.test('scoped basic test', async t => {
       '1.0.0': {
         name: '@foo/bar',
         dist: {
-          tarball: `${REG}/@foo/bar/-/foo-1.0.0.tgz`
+          tarball: `${REG}@foo/bar/-/foo-1.0.0.tgz`
         }
       }
     }
@@ -71,7 +71,7 @@ t.test('unpublish specific, last version', async t => {
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       }
     }
@@ -97,13 +97,13 @@ t.test('unpublish specific version', async t => {
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       },
       '1.0.1': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.1.tgz`
+          tarball: `${REG}foo/-/foo-1.0.1.tgz`
         }
       }
     }
@@ -119,7 +119,7 @@ t.test('unpublish specific version', async t => {
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       }
     }
@@ -180,7 +180,7 @@ t.test('packument with missing specific version assumed unpublished', async t =>
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       }
     }
@@ -205,13 +205,13 @@ t.test('unpublish specific version without dist-tag update', async t => {
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       },
       '1.0.1': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.1.tgz`
+          tarball: `${REG}foo/-/foo-1.0.1.tgz`
         }
       }
     }
@@ -227,7 +227,7 @@ t.test('unpublish specific version without dist-tag update', async t => {
       '1.0.0': {
         name: 'foo',
         dist: {
-          tarball: `${REG}/foo/-/foo-1.0.0.tgz`
+          tarball: `${REG}foo/-/foo-1.0.0.tgz`
         }
       }
     }

--- a/unpublish.js
+++ b/unpublish.js
@@ -80,7 +80,7 @@ const unpublish = async (spec, opts) => {
         ...opts,
         query: { write: true },
       })
-      const tarballUrl = new URL(dist.tarball).pathname.substr(1)
+      const tarballUrl = new URL(dist.tarball).pathname
       await npmFetch(`${tarballUrl}/-rev/${_rev}`, {
         ...opts,
         method: 'DELETE',


### PR DESCRIPTION
Fix for #5 .

An unnecessary `.substr(1)` transforms the tarball path from an absolute path to a relative path.  Has no impact if your registry is exists at root, but if you have it namespaced this will result in a duplication of the registry namespace section of the uri.

Absolute pathing should work just fine in either case.